### PR TITLE
Update bridge_layout_main.xml

### DIFF
--- a/android/src/main/res/layout/bridge_layout_main.xml
+++ b/android/src/main/res/layout/bridge_layout_main.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.design.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -12,4 +12,4 @@
         android:layout_width="fill_parent"
         android:layout_height="fill_parent" />
 
-</android.support.design.widget.CoordinatorLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
This updates 'bridge_layout_main.xml' to use androidx `coordinatorlayout`. This is needed since lichobile migrated to capacitor 2.0 which uses androidx. Without this, lichobile will crash immediately upon opening the app.